### PR TITLE
Add ability to set ownership of created files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,10 @@ None.
 
 ## Role Variables ##
 
-None.
-
-<!--
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| optional_variable | Describe its purpose. | `default_value` | No |
-| required_variable | Describe its purpose. | n/a | Yes |
--->
+| client_cert_update_file_owner_group | The name of the group that should own any files or directories created by this role. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
+| client_cert_update_file_owner_username | The name of the user that should own any files or directories created by this role. | [Omitted](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#making-variables-optional) | No |
 
 ## Dependencies ##
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,12 +2,16 @@
 # tasks file for code_gov_update
 - name: Create the /var/cyhy/client-cert-update directory
   ansible.builtin.file:
+    group: "{{ client_cert_update_file_owner_group | default(omit) }}"
     mode: 0755
+    owner: "{{ client_cert_update_file_owner_username | default(omit) }}"
     path: /var/cyhy/client-cert-update
     state: directory
 
 - name: Install the Docker Compose configuration
   ansible.builtin.copy:
     dest: /var/cyhy/client-cert-update
+    group: "{{ client_cert_update_file_owner_group | default(omit) }}"
     mode: 0644
+    owner: "{{ client_cert_update_file_owner_username | default(omit) }}"
     src: docker-compose.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,9 +2,9 @@
 # tasks file for code_gov_update
 - name: Create the /var/cyhy/client-cert-update directory
   ansible.builtin.file:
+    mode: 0755
     path: /var/cyhy/client-cert-update
     state: directory
-    mode: 0755
 
 - name: Install the Docker Compose configuration
   ansible.builtin.copy:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

The primary goal of this pull request is to add two optional variables that can be used to set ownership of any files or directories created by this role. However it also does a bit of alphabetical sorting (to align with our best practices).
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Outside of being generally useful this will allow us to set the owner of these files to the `cyhy` user when used in [cisagov/cyhy_amis](https://github.com/cisagov/cyhy_amis). This is a viable option now that the `cyhy` user is created before this role is called as part of the image building playbook. The rest is just cleanup while we're here.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass locally. This PR needs https://github.com/cisagov/skeleton-generic/pull/136 to pass GitHub Actions testing because of a dependency issue around fresh pre-commit environments and Ansible 8 (this repo's cache has expired).
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
