### PR TITLE
Replace the `ncats-dev@beta.dhs.gov` email address

### DIFF
--- a/files/docker-compose.yml
+++ b/files/docker-compose.yml
@@ -10,12 +10,12 @@ secrets:
 services:
   update:
     command:
-      - "--cc=ncats-dev@beta.dhs.gov,ncats@hq.dhs.gov"
+      - "--cc=cisa-cyhy-mailer@gwe.cisa.dhs.gov,ncats@hq.dhs.gov"
       - "--db-creds-file=/run/secrets/scan_read_creds.yml"
       - "--from=reports@cyber.dhs.gov"
       - "--html=body.html"
       - "--log-level=info"
-      - "--reply=ncats-dev@beta.dhs.gov"
+      - "--reply=cisa-cyhy-mailer@gwe.cisa.dhs.gov"
       - >-
         --subject="Latest list of web hosts that require authentication
         via client certificates"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request replaces the use of the `ncats-dev@beta.dhs.gov` email address with `cisa-cyhy-mailer@gwe.cisa.dhs.gov` in the Docker composition.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We have migrated from the legacy Google Workspace account that houses this email so we should update to a group that resides in the Google Workspace Enterprise account that we now use.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I would like to test the new email address in production (by adding it to the email list instead of replacing) once this PR is approved before merging.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
